### PR TITLE
feat: partially implement `topic.publishMessage` method

### DIFF
--- a/src/mock-pubsub.js
+++ b/src/mock-pubsub.js
@@ -61,6 +61,22 @@ const createTopic = (projectId, name) => ({
       subscriptions[name]._addMessage(message);
     });
   },
+  async publishMessage(messageOptions) {
+    await delay(5);
+    let message = {}
+
+    if (messageOptions.data){
+      message = { data: messageOptions.data, attributes: messageOptions.attributes };
+    }
+
+    if (messageOptions.json){
+      message = { data: JSON.stringify(messageOptions.json), attributes: messageOptions.attributes };
+    }
+
+    this._subscriptions.forEach(name => {
+      subscriptions[name]._addMessage(message);
+    });
+  },
   setPublishOptions() {},
   subscription(subscriptionName) {
     return getSubscriptionObject(projectId, subscriptionName);


### PR DESCRIPTION
This PR partially implements [topic.publishMessage](https://googleapis.dev/nodejs/pubsub/1.5.0/Topic.html#publishMessage) (`data`, `json`, `attribute` message options), which should replace deprecated `topic.publish` method.

