### PR TITLE
ci: setup code coverage collection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,25 @@ jobs:
           compose-file: "./docker-compose.yml"
 
       - run: npm t
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage
+          path: coverage
+
+  upload-code-coverage:
+    name: 'Upload code coverage'
+    needs: ['test-and-build']
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: code-coverage
+          path: coverage
+
+      - uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 confidential.env
+coverage

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # mock-google-cloud-pubsub
 
+[![Build Status][ci-badge]][ci]
+[![Npm version][npm-version-badge]][npm]
+[![Coveralls][coveralls-badge]][coveralls]
+
 The goal of this project is to create an in memory emulator for Google Cloud Pub/Sub so this module
 can be used interchangeably with `@google-cloud/pubsub` in integration tests for faster test execution.
 
@@ -65,3 +69,10 @@ You can use the docker pubsub emulator instead of the real pubsub:
 - in `confidential.env` set `GCP_PROJECT_ID=mock-gcp-project` and `PUBSUB_EMULATOR_HOST=localhost:8685`
 
 Run tests with `npm t` or `npm run test:watch` for watch mode.
+
+[ci-badge]: https://github.com/mkls/mock-google-cloud-pubsub/actions/workflows/ci.yml/badge.svg
+[ci]: https://github.com/mkls/mock-google-cloud-pubsub/actions/workflows/ci.yml
+[coveralls-badge]: https://coveralls.io/repos/github/mkls/mock-google-cloud-pubsub/badge.svg?branch=master
+[coveralls]: https://coveralls.io/github/mkls/mock-google-cloud-pubsub?branch=master
+[npm]: https://www.npmjs.com/package/mock-google-cloud-pubsub
+[npm-version-badge]: https://img.shields.io/npm/v/mock-google-cloud-pubsub.svg

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,6 @@
 module.exports = {
-    testTimeout: 10000
-}
+  testTimeout: 10000,
+  collectCoverage: true,
+  coverageReporters: ['lcov', 'text'],
+  collectCoverageFrom: ['<rootDir>/src/**/*.{ts,js}']
+};

--- a/test/mock-pubsub.spec.js
+++ b/test/mock-pubsub.spec.js
@@ -2,7 +2,7 @@
 
 require('dotenv-haphap').config('confidential.env');
 
-const { PubSub: MockPubSub } = require('./mock-pubsub');
+const { PubSub: MockPubSub } = require('../src/mock-pubsub');
 const { PubSub } = require('@google-cloud/pubsub');
 
 const prefix = process.env.RESOURCE_PREFIX || 'mock-pubsub-prefix-';


### PR DESCRIPTION
Setup jest to produce code coverage information and configure the pipeline to upload code coverage to [coveralls.io](https://coveralls.io/).

@mkls In order to simplify the code coverage setup I moved the test files in a dedicated `test` folder.
Is it acceptable or you'd prefer keeping tests and implementation in the same place?

PS. This pr will need a rebase once the previous ones get merged.