### PR TITLE
fix: scope getTopics and getSubscriptions to pubsub instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ To setup connection for real pubsub
 - create a `confidential.env` file in root
 - set `GCP_PROJECT_ID=<your-project-id>`
 - set `GCP_CREDENTIALS=<credentials for a service account as json>`
-- set `RESOURCE_PREFIX` to a uniq string, resources created during tests will be prefix with this value
 
 You can use the docker pubsub emulator instead of the real pubsub:
 

--- a/src/mock-pubsub.ts
+++ b/src/mock-pubsub.ts
@@ -47,12 +47,20 @@ class PubSub implements RealPubSub {
   }
 
   async getTopics() {
-    const response: GetTopicsResponse = [Object.values(topics)];
+    const projectTopics = Object.values(topics).filter((topic) =>
+      topic.name.startsWith(`projects/${this.projectId}/`),
+    );
+
+    const response: GetTopicsResponse = [projectTopics];
     return response;
   }
 
   async getSubscriptions() {
-    const response: GetSubscriptionsResponse = [Object.values(subscriptions)];
+    const projectSubscriptions = Object.values(subscriptions).filter(
+      (subscription) =>
+        subscription.name.startsWith(`projects/${this.projectId}/`),
+    );
+    const response: GetSubscriptionsResponse = [projectSubscriptions];
     return response;
   }
 


### PR DESCRIPTION
Review `getTopics` and `getSubscriptions` implementation to only return topics and subscriptions of current project id.