### PR TITLE
feat: support topic/subscription creation with full path name

### DIFF
--- a/src/mock-pubsub.ts
+++ b/src/mock-pubsub.ts
@@ -12,6 +12,8 @@ import {
   delay,
   libError,
   pickRandom,
+  makeTopicName,
+  makeSubscriptionName,
   nonExisitingTopic,
   nonExisitingSubscription,
   emptyResponse,
@@ -28,25 +30,11 @@ type MockSubscription = Subscription & {
 const topics: Record<string, Topic> = {};
 const subscriptions: Record<string, MockSubscription> = {};
 
-function makeTopicName({
-  topicName,
-  projectId,
-}: {
-  topicName: string;
-  projectId: string;
-}): string {
-  return topicName.startsWith('projects/')
-    ? topicName
-    : `projects/${projectId}/topics/${topicName}`;
-}
-
 function getSubscription(
   projectId: string,
   subscriptionName: string,
 ): Subscription {
-  const name = subscriptionName.startsWith('projects/')
-    ? subscriptionName
-    : `projects/${projectId}/subscriptions/${subscriptionName}`;
+  const name = makeSubscriptionName({ projectId, subscriptionName });
   return subscriptions[name] || nonExisitingSubscription;
 }
 
@@ -69,7 +57,7 @@ class PubSub implements RealPubSub {
   }
 
   async createTopic(topicName: string) {
-    const name = makeTopicName({ topicName, projectId: this.projectId });
+    const name = makeTopicName({ projectId: this.projectId, topicName });
     if (topics[name]) {
       throw libError(6, 'ALREADY_EXISTS: Topic already exists');
     }
@@ -81,7 +69,7 @@ class PubSub implements RealPubSub {
   }
 
   topic(topicName: string) {
-    const name = makeTopicName({ topicName, projectId: this.projectId });
+    const name = makeTopicName({ projectId: this.projectId, topicName });
     return topics[name] || nonExisitingTopic;
   }
 
@@ -101,7 +89,7 @@ function createTopic(projectId: string, name: string): Topic {
       return emptyResponse;
     },
     async createSubscription(subscriptionName: string, options: object) {
-      const name = `projects/${projectId}/subscriptions/${subscriptionName}`;
+      const name = makeSubscriptionName({ projectId, subscriptionName });
       if (subscriptions[name]) {
         throw libError(6, 'ALREADY_EXISTS: Subscription already exists');
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,6 +15,46 @@ export function pickRandom<Item>(list: Item[]): Item {
   return list[Math.floor(Math.random() * list.length)] as Item;
 }
 
+const TOPIC_NAME_REGEX = /^projects\/.+\/topics\/.+$/;
+export function makeTopicName({
+  projectId,
+  topicName,
+}: {
+  projectId: string;
+  topicName: string;
+}): string {
+  if (topicName.startsWith('projects/')) {
+    if (TOPIC_NAME_REGEX.test(topicName)) {
+      return topicName;
+    }
+    throw libError(
+      3,
+      `INVALID_ARGUMENT: Invalid [topics] name: (name=${topicName})`,
+    );
+  }
+  return `projects/${projectId}/topics/${topicName}`;
+}
+
+const SUBSCRIPTION_NAME_REGEX = /^projects\/.+\/subscriptions\/.+$/;
+export function makeSubscriptionName({
+  projectId,
+  subscriptionName,
+}: {
+  projectId: string;
+  subscriptionName: string;
+}): string {
+  if (subscriptionName.startsWith('projects/')) {
+    if (SUBSCRIPTION_NAME_REGEX.test(subscriptionName)) {
+      return subscriptionName;
+    }
+    throw libError(
+      3,
+      `INVALID_ARGUMENT: Invalid [subscriptions] name: (name=${subscriptionName})`,
+    );
+  }
+  return `projects/${projectId}/subscriptions/${subscriptionName}`;
+}
+
 // Fake responses
 
 // @ts-expect-error partial Topic implementation

--- a/test/mock-pubsub.spec.ts
+++ b/test/mock-pubsub.spec.ts
@@ -43,7 +43,7 @@ const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
     describe('creating, listing and deleting topics and subscriptions', () => {
       describe('createTopic', () => {
-        describe('with topic name', () => {
+        describe('with name', () => {
           it('should create a topic', async () => {
             const topicName = prefixedName('topic1');
             const [topic] = await pubsub.createTopic(topicName);
@@ -55,7 +55,7 @@ const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
           });
         });
 
-        describe('with topic full name', () => {
+        describe('with full name', () => {
           it('should create a topic', async () => {
             const topicName = prefixedName('topic1');
             const [topic] = await pubsub.createTopic(
@@ -66,6 +66,23 @@ const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
               `projects/${projectId}/topics/${topicName}`,
             );
             expect(typeof topic.setPublishOptions).toEqual('function');
+          });
+        });
+
+        describe('with malformed full name', () => {
+          it('should throw error', async () => {
+            const malformedName = `projects/${projectId}/malformed-name/${prefixedName('ted')}`;
+            try {
+              await pubsub.createTopic(malformedName);
+              throw new Error('should throw before');
+            } catch (error) {
+              // @ts-expect-error error expected
+              expect(error.message).toEqual(
+                `3 INVALID_ARGUMENT: Invalid [topics] name: (name=${malformedName})`,
+              );
+              // @ts-expect-error error expected
+              expect(error.code).toEqual(3);
+            }
           });
         });
 
@@ -88,7 +105,7 @@ const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
       });
 
       describe('getTopics', () => {
-        it('should return exisiting topics', async () => {
+        it('should return exsisting topics', async () => {
           await Promise.all([
             pubsub.createTopic(prefixedName('t1')),
             pubsub.createTopic(prefixedName('t2')),
@@ -146,15 +163,48 @@ const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
       });
 
       describe('topic.createSubscription', () => {
-        it('should create a subscription', async () => {
-          const [topic] = await pubsub.createTopic(prefixedName('ted'));
-          const [subscription] = await topic.createSubscription(
-            prefixedName('ted'),
-          );
+        describe('with name', () => {
+          it('should create a subscription', async () => {
+            const [topic] = await pubsub.createTopic(prefixedName('ted'));
+            const [subscription] = await topic.createSubscription(
+              prefixedName('ted'),
+            );
 
-          expect(subscription.name).toEqual(
-            `projects/${projectId}/subscriptions/${prefixedName('ted')}`,
-          );
+            expect(subscription.name).toEqual(
+              `projects/${projectId}/subscriptions/${prefixedName('ted')}`,
+            );
+          });
+        });
+
+        describe('with full name', () => {
+          it('should create a subscription', async () => {
+            const [topic] = await pubsub.createTopic(prefixedName('ted'));
+            const [subscription] = await topic.createSubscription(
+              `projects/${projectId}/subscriptions/${prefixedName('ted')}`,
+            );
+
+            expect(subscription.name).toEqual(
+              `projects/${projectId}/subscriptions/${prefixedName('ted')}`,
+            );
+          });
+        });
+
+        describe('with malformed full name', () => {
+          it('should throw error', async () => {
+            const [topic] = await pubsub.createTopic(prefixedName('ted'));
+            const malformedName = `projects/${projectId}/malformed-name/${prefixedName('ted')}`;
+            try {
+              await topic.createSubscription(malformedName);
+              throw new Error('should throw before');
+            } catch (error) {
+              // @ts-expect-error error expected
+              expect(error.message).toEqual(
+                `3 INVALID_ARGUMENT: Invalid [subscriptions] name: (name=${malformedName})`,
+              );
+              // @ts-expect-error error expected
+              expect(error.code).toEqual(3);
+            }
+          });
         });
 
         it('should throw error if subscription already exists', async () => {

--- a/test/mock-pubsub.spec.ts
+++ b/test/mock-pubsub.spec.ts
@@ -43,15 +43,30 @@ const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
     describe('creating, listing and deleting topics and subscriptions', () => {
       describe('createTopic', () => {
-        it('should create a topic', async () => {
-          const topicName = prefixedName('topic1');
+        describe('with topic name', () => {
+          it('should create a topic', async () => {
+            const topicName = prefixedName('topic1');
+            const [topic] = await pubsub.createTopic(topicName);
 
-          const [topic] = await pubsub.createTopic(topicName);
+            expect(topic.name).toEqual(
+              `projects/${projectId}/topics/${topicName}`,
+            );
+            expect(typeof topic.setPublishOptions).toEqual('function');
+          });
+        });
 
-          expect(topic.name).toEqual(
-            `projects/${projectId}/topics/${topicName}`,
-          );
-          expect(typeof topic.setPublishOptions).toEqual('function');
+        describe('with topic full name', () => {
+          it('should create a topic', async () => {
+            const topicName = prefixedName('topic1');
+            const [topic] = await pubsub.createTopic(
+              `projects/${projectId}/topics/${topicName}`,
+            );
+
+            expect(topic.name).toEqual(
+              `projects/${projectId}/topics/${topicName}`,
+            );
+            expect(typeof topic.setPublishOptions).toEqual('function');
+          });
         });
 
         it('should throw error if topic already exists', async () => {


### PR DESCRIPTION
Review the logic around creating topic and subscriptions via full name.

I was surprised to see that the pub sub emulator allows registering topics and subscription with full path name containing a different project id. Not sure whether it's by design or an emulator limitation.