### PR TITLE
feat: add interceptMessage option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,36 @@ const { PubSub: MockPubSub } = require('mock-google-cloud-pubsub')
 const pubsub = process.env.NODE_ENV !== 'test' ? new PubSub({ ... }) : new MockPubSub()
 ```
 
+### Inspect or mock Message
+
+You can inspect the message emitted by the mocked pubsub package.
+You can do the following:
+
+```js
+// if you use jest
+const inspectMessage = jest.fn();
+const mockAck = jest.fn();
+
+const mockPubsub = new MockPubSub(
+  {},
+  {
+    interceptMessage: (msg) => {
+      //
+      inspectMessage(msg);
+
+      // override the default ack function
+      msg.ack = mockAck;
+
+      // or spy it
+      jest.spyOn(msg, 'ack');
+
+      // remember to alaways return a Message instance
+      return msg;
+    },
+  },
+);
+```
+
 ## Changelog
 
 ### 2.1.0

--- a/test/mock-pubsub-test-only-features.spec.ts
+++ b/test/mock-pubsub-test-only-features.spec.ts
@@ -1,0 +1,49 @@
+import { PubSub } from '../src/mock-pubsub';
+
+describe('test only features', () => {
+  it('enable message inspection', async () => {
+    const inspectMessage = jest.fn((m) => m);
+    const pubsub = new PubSub(
+      { projectId: 'project-id-1' },
+      {
+        interceptMessage: inspectMessage,
+      },
+    );
+
+    const [topic] = await pubsub.createTopic('topic');
+    await topic.createSubscription('subscription');
+
+    await topic.publish(Buffer.from('Message123'));
+
+    expect(inspectMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: Buffer.from('Message123'),
+      }),
+    );
+  });
+
+  it('mock ack', async () => {
+    let ackSpy;
+
+    const pubsub = new PubSub(
+      { projectId: 'project-id-2' },
+      {
+        interceptMessage: (msg) => {
+          ackSpy = jest.spyOn(msg, 'ack');
+          return msg;
+        },
+      },
+    );
+
+    const [topic] = await pubsub.createTopic('topic');
+    const [subscription] = await topic.createSubscription('subscription');
+
+    subscription.on('message', (msg) => {
+      msg.ack();
+    });
+
+    await topic.publish(Buffer.from('Message123'));
+
+    expect(ackSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
The aim of this PR is to enable the introspection of emitted messages, as well as the mocking or spying of `ack`, `nack`, and all other functions available on the Message object. It has been implemented following the principle of inversion of control and is designed to be testing-framework agnostic.

The issue that is trying to solve is described here https://github.com/mkls/mock-google-cloud-pubsub/issues/13#issuecomment-2786727395.