### PR TITLE
test: use official google/cloud-sdk docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 The goal of this project is to develop an in-memory emulator for Google Cloud Pub/Sub, enabling this module to be used as a drop-in replacement for `@google-cloud/pubsub` in integration tests.
 
-As an alternative to this package, you may consider using a [Pub/Sub emulator Docker image](https://github.com/marcelcorso/gcloud-pubsub-emulator). However, this package is recommended if the Docker-based emulator does not meet your performance requirements.
+As an alternative to this package, you may consider using a [Pub/Sub emulator Docker image](https://hub.docker.com/r/google/cloud-sdk). However, this package is recommended if the Docker-based emulator does not meet your performance requirements.
 
 ## Installation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,6 @@
-version: '3'
-
 services:
-  pubsub:
-    container_name: pubsub-for-mock-pubsub
-    image: messagebird/gcloud-pubsub-emulator:latest
-    environment:
-      - PUBSUB_PROJECT1=mock-gcp-project
+  pubsub-emulator:
+    image: google/cloud-sdk:emulators
+    command: gcloud beta emulators pubsub start --host-port=0.0.0.0:8685
     ports:
-      - 8685:8681
+      - 8685:8685

--- a/test/publishing-and-consuming-messages.test.ts
+++ b/test/publishing-and-consuming-messages.test.ts
@@ -192,6 +192,7 @@ describe('Publishing and consuming messages', () => {
           await topic.publish(Buffer.from('message-data'));
         }
 
+        // @NOTE This test in not deterministic and might fail from time to time
         expect(receivedMessages1.length).toBeGreaterThan(1);
         expect(receivedMessages2.length).toBeGreaterThan(1);
         subscription.removeAllListeners();


### PR DESCRIPTION
Shall we consider using a specific version like: `519.0.0-emulators` instead of the latest stable which could possibly introduce breaking changes in future?