### PR TITLE
feat: expose types

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,25 +45,6 @@ import { PubSub: MockPubSub } from 'mock-google-cloud-pubsub'
 const pubsub = process.env.NODE_ENV !== 'test' ? new PubSub({ ... }) : new MockPubSub()
 ```
 
-### TypeScript
-
-Although fully written in TypeScript, `mock-google-cloud-pubsub` does not currently expose type definitions. The suggestion is to type cast the expected `@google-cloud/pubsub` types:
-
-```ts
-// @ts-expect-error mock-google-cloud-pubsub does not expose type definitions
-import { PubSub as PubSubMock } from 'mock-google-cloud-pubsub';
-import type { ClientConfig, PubSub } from '@google-cloud/pubsub';
-
-export function makeMockedPubSub({
-  options,
-}: {
-  options: ClientConfig;
-}): PubSub {
-  const pubSub = new PubSubMock(options);
-  return pubSub;
-}
-```
-
 ## Changelog
 
 ### 3.0.2

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ import { PubSub: MockPubSub } from 'mock-google-cloud-pubsub'
 const pubsub = process.env.NODE_ENV !== 'test' ? new PubSub({ ... }) : new MockPubSub()
 ```
 
+## `@google-cloud/pubsub` versions support
+
+| mock-google-cloud-pubsub | @google-cloud/pubsub |
+| ------------------------ | -------------------- |
+| v3.1.0 +                 | v4.X.X -> v5.X.X     |
+
 ## Changelog
 
 ### 3.0.2

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.2",
   "description": "mock @google-cloud/pubsub package in integration tests",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],
@@ -28,7 +29,6 @@
   },
   "homepage": "https://github.com/mkls/mock-google-cloud-pubsub#readme",
   "devDependencies": {
-    "@google-cloud/pubsub": "^4.11.0",
     "@jest/types": "^29.6.3",
     "@tsconfig/node18": "^18.2.4",
     "@types/jest": "^29.5.14",
@@ -40,5 +40,8 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3",
     "wait-for-expect": "^3.0.2"
+  },
+  "peerDependencies": {
+    "@google-cloud/pubsub": "^4.0.0 || ^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mock-google-cloud-pubsub",
   "version": "3.0.2",
   "description": "mock @google-cloud/pubsub package in integration tests",
-  "main": "dist/mock-pubsub.js",
+  "main": "dist/index.js",
   "files": [
     "dist"
   ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export { PubSub } from './mock-pubsub';

--- a/test/message.test.ts
+++ b/test/message.test.ts
@@ -45,7 +45,6 @@ describe('Message', () => {
         expect(message.publishTime).toEqual(expect.any(Date));
         expect(message.id).toEqual(expect.any(String));
         expect(message.received).toEqual(expect.any(Number));
-        expect(message.isExactlyOnceDelivery).toBe(false);
         expect(message.orderingKey).toBe('');
 
         expect(message.endParentSpan).toEqual(expect.any(Function));

--- a/test/test-utils/clear-pubsub-instance.ts
+++ b/test/test-utils/clear-pubsub-instance.ts
@@ -1,5 +1,5 @@
 import { PubSub } from '@google-cloud/pubsub';
-import { PubSub as MockPubSub } from '../../src/mock-pubsub';
+import { PubSub as MockPubSub } from '../../src';
 
 export async function clearPubSubInstance(pubsub: PubSub | MockPubSub) {
   const [topics] = await pubsub.getTopics();

--- a/test/test-utils/make-pubsub-instances.ts
+++ b/test/test-utils/make-pubsub-instances.ts
@@ -1,5 +1,5 @@
 import { PubSub } from '@google-cloud/pubsub';
-import { PubSub as MockPubSub } from '../../src/mock-pubsub';
+import { PubSub as MockPubSub } from '../../src';
 
 export function makePubSubInstances({ projectId }: { projectId?: string }) {
   return [

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "include": ["./src"],
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "declaration": true
   }
 }


### PR DESCRIPTION
This PR is a POC to re-expose `@google-cloud/pubsub` (v4 or v5, the same dependency installed by the consumer) by defining the package as a peer dependency.

Extra: this allows officially defining which `@google-cloud/pubsub` a given `mock-google-cloud-pubsub` version is expected to support. Long term we might/should focus on the latest major, only.